### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,15 @@ RUN apt-get update && apt-get install -y zabbix-agent && apt-get clean
 # Install module
 RUN pip install .
 
+# Install entry-point script
+ADD docker-entry-point.sh /usr/local/bin/docker-entry-point.sh
+
 # REQUIRED INPUTS
 
 # Hostname or IP address of Zabbix server
 ENV ZABBIX_SERVER zabbix-server
 
-# Specify hostname of Zabbix events dedicated to the daemon
-# May be the FQDN or host running this container.
-ENV ZABBIX_HOST daemon.localdomain
-
 # Container needs to access the socket on host
 VOLUME /var/run/docker.sock
 
-CMD "docker-zabbix-sender"
+ENTRYPOINT [ "docker-entry-point.sh" ]

--- a/docker-entry-point.sh
+++ b/docker-entry-point.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
-# Set ZABBIX_HOST if not already done
+# Set ZABBIX_HOST environment variable 
+# to container hostname if not already set.
 export ZABBIX_HOST=${ZABBIX_HOST:-$HOSTNAME}
 
-# if `docker run` first argument start with `-` the user is passing jenkins swarm launcher arguments
+# if `docker run` first argument start with `-`, then
+# the user is passing arguments to docker-zabbix-sender
 if [[ $# -lt 1 ]] || [[ "$1" == "-"* ]]; then
-
   exec docker-zabbix-sender "$@"
 fi
 
-# As argument is not jenkins, assume user want to run his own process, for sample a `bash` shell to explore this image
+# As argument is not related to docker-zabbix-sender,
+# then assume that user wants to run his own process,
+# for example a `bash` shell to explore this image
 exec "$@"

--- a/docker-entry-point.sh
+++ b/docker-entry-point.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Set ZABBIX_HOST if not already done
+export ZABBIX_HOST=${ZABBIX_HOST:-$HOSTNAME}
+
+# if `docker run` first argument start with `-` the user is passing jenkins swarm launcher arguments
+if [[ $# -lt 1 ]] || [[ "$1" == "-"* ]]; then
+
+  exec docker-zabbix-sender "$@"
+fi
+
+# As argument is not jenkins, assume user want to run his own process, for sample a `bash` shell to explore this image
+exec "$@"

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -96,6 +96,19 @@ You need to provide some inputs to the container:
 1. **ZABBIX_HOST**: FQDN server used to publish Zabbix events related to the Docker daemon. Same than `Hostname` key in `/etc/zabbix/zabbix_agentd.conf`
 1. Access to `/var/run/docker.sock` on host running the container to retrieve live statistics about running containers.
 
+### Alternate way for ZABBIX_HOST
+
+Specifying ZABBIX_HOST is optional if the environment variable is undefined, it will be defaulted to the container hostname. Since the container hostname is random you should use the `-h` option to get a predictable host name:
+
+```shell
+docker run                                          \
+    --link your-zabbix-container:zabbix-server      \
+    -h <HOST_NAME>                                  \
+    -v /var/run/docker.sock:/var/run/docker.sock    \
+    dockermeetupsinbordeaux/docker-zabbix-sender
+```
+
+
 # Provided metrics out of the box
 
 The following Zabbix template provides events for every metric specified below.


### PR DESCRIPTION
This PR basically adds a entry-point script and give the user the ability to choose to use either a environment variable of the container hostname for ZABBIX_HOST.

Although I could have implemented dropping the privileges to a non root user I finally decided that it might not be worth the added complexity as having access to the docker daemon gives more or less root privileges. 